### PR TITLE
kaminariを使用してページング機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ gem 'net-pop'
 gem 'net-smtp'
 
 gem 'carrierwave'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -296,6 +308,7 @@ DEPENDENCIES
   erb_lint
   i18n_generators
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   net-imap
   net-pop

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.all
+    @books = Book.order(:id).page(params[:page]).per(2)
   end
 
   # GET /books/1

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -31,3 +31,5 @@
 <br>
 
 <%= link_to t('views.common.new'), new_book_path %>
+
+<%= paginate @books %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,6 +215,11 @@ ja:
       delete_confirm: よろしいですか？
       title_new: "%{name}の新規作成"
       title_edit: "%{name}の編集"
+    pagination:
+      first: 最初へ
+      last: 最後へ
+      next: 次へ
+      previous: 前へ
   controllers:
     common:
       notice_create: "%{name}が作成されました。"


### PR DESCRIPTION
### 実装するためにやったこと
- gem 'kaminari'をGemfileに記述し、インストール
- books_controller.rb にページ機能を実装するために編集
- index.html.erb にページング機能の表示
- ja.ymlを編集して、kaminariの表示を日本語対応
### 必要要件
- 本の一覧ページにページング処理を付ける（1ページあたりの表示件数は任意。要スクリーンショット）
2件で区切る様に指定しています。
（新たに登録しなくてもページ機能を実装できるため）
### 歓迎要件
- kaminariのページングを日本語化
ja.ymlに記述し、next, previous などの様にデフォルトでは英語だったものをそれに対応した日本語訳を設定済み